### PR TITLE
macOS Big Sur support

### DIFF
--- a/NoTouchID/kern_start.cpp
+++ b/NoTouchID/kern_start.cpp
@@ -63,7 +63,7 @@ PluginConfiguration ADDPR(config) {
 	bootargBeta,
 	arrsize(bootargBeta),
 	KernelVersion::HighSierra,
-	KernelVersion::Catalina,
+	KernelVersion::BigSur,
 	[]() {
 		lilu.onProcLoad(ADDPR(procInfo), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryMod), ADDPR(binaryModSize));
 	}


### PR DESCRIPTION
Hi, by setting kernel version from `Catalina` to `BigSur` it's now working with Big Sur without -nobiobeta boot-arg.
Thanks